### PR TITLE
Change the $wrapper->git command to support a working dir

### DIFF
--- a/src/GitWrapper/GitWrapper.php
+++ b/src/GitWrapper/GitWrapper.php
@@ -329,9 +329,9 @@ class GitWrapper
      *
      * @see GitWrapper::run()
      */
-    public function git($command_line)
+    public function git($command_line, $cwd = NULL)
     {
-        $command = new Git($command_line);
+        $command = new Git($command_line, $cwd);
         return $this->run($command);
     }
 


### PR DESCRIPTION
Executing a $wrapper->git("some git command"); will always fail due to the lack of context of where it should execute the command
