### PR TITLE
Ability to receive live output from running git process

### DIFF
--- a/src/GitWrapper/Event/GitEvents.php
+++ b/src/GitWrapper/Event/GitEvents.php
@@ -44,6 +44,13 @@ final class GitEvents
      * @var string
      */
     const GIT_BYPASS = 'git.command.bypass';
+    
+    /**
+     * Event thrown when processing git command
+     * 
+     * @var string
+     */
+    const GIT_PROCESS = 'git.command.process';
 
     /**
      * Deprecated in favor of GitEvents::GIT_PREPARE.

--- a/src/GitWrapper/Event/GitProcessEvent.php
+++ b/src/GitWrapper/Event/GitProcessEvent.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * A PHP wrapper around the Git command line utility.
+ *
+ * @license GNU General Public License, version 3
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt
+ * @see https://github.com/cpliakas/git-wrapper
+ * @copyright Copyright (c) 2013 Acquia, Inc.
+ * @author  Ryan Hamilton-Schumacher <ryan@38pages.com>
+ */
+
+namespace GitWrapper\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Process event instance passed as a result of git.process commands.
+ */
+class GitProcessEvent extends Event
+{
+    /**
+     * The GitEvent object that the git.process event will use.
+     *
+     * @var GitEvent
+     */
+    protected $_event;
+
+    /**
+     * The type of output (out or err)
+     *
+     * @var string
+     */
+    protected $_type;
+
+    /**
+     * Some bytes from the output in real-time
+     *
+     * @var string
+     */
+    protected $_buffer;
+
+    /**
+     * Constructs a GitProcessEvent object.
+     *
+     * @param GitEvent $event
+     *   The GitEvent object that the git.process event will use.
+     * @param string $type
+     *   The type of output (out or err)
+     * @param string $buffer
+     *   Some bytes from the output in real-time
+     */
+    public function __construct(GitEvent $event, $type, $buffer)
+    {
+        $this->_event = $event;
+        $this->_type = $type;
+        $this->_buffer = $buffer;
+    }
+
+    /**
+     * Gets the GitWrapper object that likely instantiated this class.
+     *
+     * @return GitWrapper
+     */
+    public function getWrapper()
+    {
+        return $this->_event->_wrapper;
+    }
+
+    /**
+     * Gets the Process object being run.
+     *
+     * @return Process
+     */
+    public function getProcess()
+    {
+        return $this->_event->_process;
+    }
+
+    /**
+     * Gets the GitCommand object being executed.
+     *
+     * @return GitCommand
+     */
+    public function getCommand()
+    {
+        return $this->_event->_command;
+    }
+
+    /**
+     * Gets the output type object being executed.
+     *
+     * @return string (out or err)
+     */
+    public function getType()
+    {
+        return $this->_type;
+    }
+
+    /**
+     * Gets the output type object being executed.
+     *
+     * @return string (out or err)
+     */
+    public function getBuffer()
+    {
+        return $this->_buffer;
+    }
+}

--- a/test/GitWrapper/Test/Event/TestListener.php
+++ b/test/GitWrapper/Test/Event/TestListener.php
@@ -3,6 +3,7 @@
 namespace GitWrapper\Test\Event;
 
 use GitWrapper\Event\GitEvent;
+use GitWrapper\Event\GitProcessEvent;
 
 class TestListener
 {
@@ -20,6 +21,17 @@ class TestListener
      */
     protected $_event;
 
+    /**
+     * The type of buffer from the processEvent passed to the onProcess method
+     */
+    protected $_onProcessBufferType;
+
+    /**
+     * The buffer string from the processEvent passed to the onProcess method
+     */
+    protected $_onProcessBuffer;
+
+
     public function methodCalled($method)
     {
         return in_array($method, $this->_methods);
@@ -31,6 +43,22 @@ class TestListener
     public function getEvent()
     {
         return $this->_event;
+    }
+
+    /**
+     * @return  string
+     */
+    public function getOnProcessBufferType()
+    {
+        return $this->_onProcessBufferType;
+    }
+
+    /**
+     * @return  string
+     */
+    public function getOnProcessBuffer()
+    {
+        return $this->_onProcessBuffer;
     }
 
     public function onPrepare(GitEvent $event)
@@ -52,5 +80,12 @@ class TestListener
     public function onBypass(GitEvent $event)
     {
         $this->_methods[] = 'onBypass';
+    }
+
+    public function onProcess(GitProcessEvent $processEvent)
+    {
+        $this->_methods[] = 'onProcess';
+        $this->_onProcessBufferType = $processEvent->getType();
+        $this->_onProcessBuffer = $processEvent->getBuffer();
     }
 }

--- a/test/GitWrapper/Test/GitListenerTest.php
+++ b/test/GitWrapper/Test/GitListenerTest.php
@@ -14,6 +14,7 @@ class GitListenerTest extends GitWrapperTestCase
         $this->_wrapper->version();
 
         $this->assertTrue($listener->methodCalled('onPrepare'));
+        $this->assertTrue($listener->methodCalled('onProcess'), "Expecting onProcess listener to be triggered");
         $this->assertTrue($listener->methodCalled('onSuccess'));
         $this->assertFalse($listener->methodCalled('onError'));
         $this->assertFalse($listener->methodCalled('onBypass'));
@@ -25,6 +26,7 @@ class GitListenerTest extends GitWrapperTestCase
         $this->runBadCommand(true);
 
         $this->assertTrue($listener->methodCalled('onPrepare'));
+        $this->assertTrue($listener->methodCalled('onProcess'), "Expecting onProcess listener to not be triggered");
         $this->assertFalse($listener->methodCalled('onSuccess'));
         $this->assertTrue($listener->methodCalled('onError'));
         $this->assertFalse($listener->methodCalled('onBypass'));
@@ -38,11 +40,28 @@ class GitListenerTest extends GitWrapperTestCase
         $output = $this->_wrapper->version();
 
         $this->assertTrue($listener->methodCalled('onPrepare'));
+        $this->assertFalse($listener->methodCalled('onProcess'), "Expecting onProcess listener to not be triggered");
         $this->assertFalse($listener->methodCalled('onSuccess'));
         $this->assertFalse($listener->methodCalled('onError'));
         $this->assertTrue($listener->methodCalled('onBypass'));
 
         $this->assertEmpty($output);
+    }
+
+    public function testGitProcess()
+    {
+        $listener = $this->addListener();
+
+        $this->_wrapper->version();
+
+        $this->assertTrue($listener->methodCalled('onProcess'), "Expecting onProcess listener to have been triggered");
+        $this->assertStringStartsWith('out', $listener->getOnProcessBufferType('onProcess'), "Expecting onProcess listener recieved buffer type 'out'");
+        $this->assertStringStartsWith('git version', $listener->getOnProcessBuffer('onProcess'), "Expecting onProcess listener recieved buffer to start with 'git version'");
+
+        $this->runBadCommand(true);
+        $this->assertTrue($listener->methodCalled('onProcess'), "Expecting onProcess listener to have been triggered");
+        $this->assertStringStartsWith('err', $listener->getOnProcessBufferType('onProcess'), "Expecting onProcess listener recieved buffer type 'err'");
+        $this->assertStringStartsWith('git: \'a-bad-command\'', $listener->getOnProcessBuffer('onProcess'), "Expecting onProcess listener recieved buffer to start with 'git: \'a-bad-command\''");
     }
 
     public function testEvent()

--- a/test/GitWrapper/Test/GitWrapperTestCase.php
+++ b/test/GitWrapper/Test/GitWrapperTestCase.php
@@ -58,6 +58,7 @@ class GitWrapperTestCase extends \PHPUnit_Framework_TestCase
         $dispatcher->addListener(GitEvents::GIT_SUCCESS, array($listener, 'onSuccess'));
         $dispatcher->addListener(GitEvents::GIT_ERROR, array($listener, 'onError'));
         $dispatcher->addListener(GitEvents::GIT_BYPASS, array($listener, 'onBypass'));
+        $dispatcher->addListener(GitEvents::GIT_PROCESS, array($listener, 'onProcess'));
 
         return $listener;
     }


### PR DESCRIPTION
Added new event 'git.process' to permit this feature.

Add GIT_PROCESS constant

Add ability to receive live output from running command.

> The run() method takes care of the subtle differences between the
> different platforms when executing the command.
> 
> When executing a long running command (like rsync-ing files to a remote
> server), you can give feedback to the end user in real-time by passing
> an anonymous function to the run() method.

Ref: http://symfony.com/doc/2.0/components/process.html
