### PR TITLE
GitWorkingCopy::add() or rm() didn't work as expected due escaping strategy

### DIFF
--- a/src/GitWrapper/GitCommand.php
+++ b/src/GitWrapper/GitCommand.php
@@ -105,28 +105,6 @@ class GitCommand
     }
 
     /**
-     * Properly escapes file patterns that are passed as arguments.
-     *
-     * This method only escape paths with files that have extensions. If the
-     * path does not have an extension, there is no need to excape the periods.
-     *
-     * This is most useful for Git "add" and "rm" commands.
-     *
-     * @param string $filepattern
-     *   The file pattern being escaped.
-     *
-     * @return string
-     */
-    static public function escapeFilepattern($filepattern)
-    {
-        $path_info = pathinfo($filepattern);
-        if (isset($path_info['extension'])) {
-            $path_info['basename'] = str_replace('.', '\\.', $path_info['basename']);
-        }
-        return $path_info['dirname'] . DIRECTORY_SEPARATOR . $path_info['basename'];
-    }
-
-    /**
      * Returns Git command being run, e.g. "clone", "commit", etc.
      *
      * @return string

--- a/src/GitWrapper/GitWorkingCopy.php
+++ b/src/GitWrapper/GitWorkingCopy.php
@@ -85,26 +85,6 @@ class GitWorkingCopy
     }
 
     /**
-     * Properly escapes file patterns that are passed as arguments.
-     *
-     * This method only escape paths with files that have extensions. If the
-     * path does not have an extension, there is no need to excape the periods.
-     *
-     * This is most useful for Git "add" and "rm" commands.
-     *
-     * @param string $filepattern
-     *   The file pattern being escaped.
-     *
-     * @deprecated since version 1.0.0
-     *
-     * @see GitCommand::escapeFilepattern()
-     */
-    public function escapeFilepattern($filepattern)
-    {
-        return GitCommand::escapeFilepattern($filepattern);
-    }
-
-    /**
      * Gets the output captured by the last run Git commnd(s).
      *
      * @return string
@@ -337,7 +317,7 @@ class GitWorkingCopy
     {
         $args = array(
             'add',
-            GitCommand::escapeFilepattern($filepattern),
+            $filepattern,
             $options,
         );
         return $this->run($args);
@@ -850,7 +830,7 @@ class GitWorkingCopy
     {
         $args = array(
             'rm',
-            GitCommand::escapeFilepattern($filepattern),
+            $filepattern,
             $options,
         );
         return $this->run($args);

--- a/src/GitWrapper/Test/GitCommandTest.php
+++ b/src/GitWrapper/Test/GitCommandTest.php
@@ -52,11 +52,4 @@ class GitCommandTest extends GitWrapperTestCase
 
         $this->assertEquals($expected, $command_line);
     }
-
-    public function testEscapeFilepattern()
-    {
-        $filepattern = 'a.directory/test.txt';
-        $expected = 'a.directory/test\\.txt';
-        $this->assertEquals($expected, GitCommand::escapeFilepattern($filepattern));
-    }
 }

--- a/src/GitWrapper/Test/GitWorkingCopyTest.php
+++ b/src/GitWrapper/Test/GitWorkingCopyTest.php
@@ -100,17 +100,6 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $git->badMethod();
     }
 
-    /**
-     * @deprecated since version 1.0.0
-     *
-     * @see GitCommand::escapeFilepattern()
-     */
-    public function testEscapeFilepattern()
-    {
-        $git = $this->getWorkingCopy();
-        $this->assertEquals($git->escapeFilepattern('./test.txt'), './test\.txt');
-    }
-
     public function testIsCloned()
     {
         $git = $this->getWorkingCopy();


### PR DESCRIPTION
if you run commands like $workingCopy->add('path/to/file.txt') files was never staged within the git repository (checked manually with git status). 
A while of debugging shows, that the file-extension escaping strategy caused the issue. If you run $workingCopy->run('add', 'path/to/file.txt') without escaping the file through the GitCommand::escapeFilepattern() method, adding (or similar rm() ) works as expected.
