### PR TITLE
Create a function to return the current branch of the working copy.

### DIFF
--- a/src/GitWrapper/GitBranches.php
+++ b/src/GitWrapper/GitBranches.php
@@ -94,11 +94,11 @@ class GitBranches implements \IteratorAggregate
     }
 
     /**
-     * Returns currently active branch of the working copy.
+     * Returns currently active branch (HEAD) of the working copy.
      *
      * @return array
      */
-    public function current()
+    public function head()
     {
         return (string) $this->git->run(array('rev-parse --abbrev-ref HEAD'));
     }


### PR DESCRIPTION
I needed a way to simply return the current branch from the working copy.

I learned that this command does it:

`rev-parse --abbrev-ref HEAD`

So I added a "current()" function to GitBranches class.
