### PR TITLE
git-ssh-wrapper - pass all command line arguments to ssh

### DIFF
--- a/bin/git-ssh-wrapper.sh
+++ b/bin/git-ssh-wrapper.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-ssh -i $GIT_SSH_KEY -p $GIT_SSH_PORT -o StrictHostKeyChecking=no -o IdentitiesOnly=yes $1 $2
+ssh -i $GIT_SSH_KEY -p $GIT_SSH_PORT -o StrictHostKeyChecking=no -o IdentitiesOnly=yes "$@"


### PR DESCRIPTION
This fixes an issue connecting to ssh on non-standard ports.

For example, the following code:

    $git = new GitWrapper();
    $git->setPrivateKey('/path/to/id_rsa', 7999);
    $git->cloneRepository('ssh://git@example.com:7999/project/project.git', '/tmp/project');

results in ssh displaying a usage message and an error.

The problem is that 5 arguments are actually passed to the wrapper script:

    -p 7999 git@example.com git-upload-pack '/project/project.git'

These all need to be passed to the ssh command for it to work correctly.

I wasn't sure how to write a test for this, please let me know if you'd like me to figure something out and submit it.