### PR TITLE
Remove terminating newline when retrieving the branch HEAD

### DIFF
--- a/src/GitWrapper/GitBranches.php
+++ b/src/GitWrapper/GitBranches.php
@@ -96,10 +96,10 @@ class GitBranches implements \IteratorAggregate
     /**
      * Returns currently active branch (HEAD) of the working copy.
      *
-     * @return array
+     * @return string
      */
     public function head()
     {
-        return (string) $this->git->run(array('rev-parse --abbrev-ref HEAD'));
+        return trim((string) $this->git->run(array('rev-parse --abbrev-ref HEAD')));
     }
 }


### PR DESCRIPTION
When the branch HEAD is retrieved in `GitBranches::head()` the output of `git rev-parse --abbrev-ref HEAD` is returned verbatim, meaning that it includes the terminating newline.

We should remove the unnecessary whitespace, so we can use the return value of this method without having to trim it every time.