### PR TITLE
[Feature] Allow testing for minimum versions of Git available

### DIFF
--- a/src/GitWrapper/GitWrapper.php
+++ b/src/GitWrapper/GitWrapper.php
@@ -392,6 +392,49 @@ class GitWrapper
     }
 
     /**
+     * Returns a boolean indicating if the version of Git available is
+     * equal to a minimum version or later.  All of the arguments are
+     * optional, and if called with no arguments the method tests for
+     * version 2.0.0 of Git.
+     *
+     * @param int $major (optional)
+     *   The major version number.
+     *
+     * @param int $minor (optional)
+     *   The minor version number.
+     *
+     * @param int $patch (optional)
+     *   The patch version number.
+     *
+     * @return bool
+     *
+     * @throws \GitWrapper\GitException
+     */
+    public function hasMinimumVersion($major = 2, $minor = 0, $patch = 0)
+    {
+        $version_string = $this->version();
+        $version_regex = '/git version (\d+)\.(\d+)\.(\d+)/';
+        $matches = array();
+
+        preg_match($version_regex, $version_string, $matches);
+
+        if ((int) $matches[1] < $major) {
+            return false;
+        }
+        else if ((int) $matches[2] < $minor and
+                 (int) $matches[1] <= $major) {
+            return false;
+        }
+        else if ((int) $matches[3] < $patch and
+                 (int) $matches[2] <= $minor and
+                 (int) $matches[1] <= $major) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Parses name of the repository from the path.
      *
      * For example, passing the "git@github.com:cpliakas/git-wrapper.git"

--- a/test/GitWrapper/Test/GitWrapperTest.php
+++ b/test/GitWrapper/Test/GitWrapperTest.php
@@ -66,6 +66,25 @@ class GitWrapperTest extends GitWrapperTestCase
         $this->assertGitVersion($version);
     }
 
+    public function testHasMinimumVersion()
+    {
+        // Do we have Git 2.0.0 or later?
+        $this->assertTrue($this->wrapper->hasMinimumVersion());
+
+        // Do we have Git 1.0.0 or later?
+        $this->assertTrue($this->wrapper->hasMinimumVersion(1));
+
+        // Do we have Git 1.8.0 or later?
+        $this->assertTrue($this->wrapper->hasMinimumVersion(1, 8));
+
+        // Do we have Git 1.8.4 or later?
+        $this->assertTrue($this->wrapper->hasMinimumVersion(1, 8, 4));
+
+        // Do we have Git 3.0.0 or later?  We shouldn't, unless we are
+        // a time-traveler from the future.
+        $this->assertFalse($this->wrapper->hasMinimumVersion(3));
+    }
+
     public function testSetPrivateKey()
     {
         $key = './test/id_rsa';


### PR DESCRIPTION
This patch implements a new method:

    GitWrapper::hasMinimumVersion($major, $minor, $patch)

This method makes it possible for code using the library to test
whether or not a minimum version of Git is available.  For example, we
can write...

    if ($wrapper->hasMinimumVersion(2, 5)) { ... }

...to determine if Git version 2.5.0 or later is available.  Not only
does this help library users to check for Git versions, it also allows
us to implement methods in the API which support Git commands that may
not be available on some systems depending on which version of Git the
developer has available, e.g. `git worktree`, which requires Git 2.5
or later.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>