### PR TITLE
Add helper methods for working with remotes.

### DIFF
--- a/src/GitWrapper/Event/GitLoggerListener.php
+++ b/src/GitWrapper/Event/GitLoggerListener.php
@@ -98,46 +98,51 @@ class GitLoggerListener implements EventSubscriberInterface, LoggerAwareInterfac
     }
 
     /**
-     * Adds a logg message using the level defined in the mappings.
+     * Adds a log message using the level defined in the mappings.
      *
      * @param \GitWrapper\Event\GitEvent $event
      * @param string $message
      * @param array $context
+     * @param string $eventName
      *
      * @throws \DomainException
      */
-    public function log(GitEvent $event, $message, array $context = array())
+    public function log(GitEvent $event, $message, array $context = array(), $eventName = NULL)
     {
-        $method = $this->getLogLevelMapping($event->getName());
+        // Provide backwards compatibility with Symfony 2.
+        if (empty($eventName) && method_exists($event, 'getName')) {
+            $eventName = $event->getName();
+        }
+        $method = $this->getLogLevelMapping($eventName);
         if ($method !== false) {
             $context += array('command' => $event->getProcess()->getCommandLine());
             $this->logger->$method($message, $context);
         }
     }
 
-    public function onPrepare(GitEvent $event)
+    public function onPrepare(GitEvent $event, $eventName = NULL)
     {
-        $this->log($event, 'Git command preparing to run');
+        $this->log($event, 'Git command preparing to run', array(), $eventName);
     }
 
-    public function handleOutput(GitOutputEvent $event)
+    public function handleOutput(GitOutputEvent $event, $eventName = NULL)
     {
         $context = array('error' => $event->isError() ? true : false);
-        $this->log($event, $event->getBuffer(), $context);
+        $this->log($event, $event->getBuffer(), $context, $eventName);
     }
 
-    public function onSuccess(GitEvent $event)
+    public function onSuccess(GitEvent $event, $eventName = NULL)
     {
-        $this->log($event, 'Git command successfully run');
+        $this->log($event, 'Git command successfully run', array(), $eventName);
     }
 
-    public function onError(GitEvent $event)
+    public function onError(GitEvent $event, $eventName = NULL)
     {
-        $this->log($event, 'Error running Git command');
+        $this->log($event, 'Error running Git command', array(), $eventName);
     }
 
-    public function onBypass(GitEvent $event)
+    public function onBypass(GitEvent $event, $eventName = NULL)
     {
-        $this->log($event, 'Git command bypassed');
+        $this->log($event, 'Git command bypassed', array(), $eventName);
     }
 }

--- a/src/GitWrapper/GitWorkingCopy.php
+++ b/src/GitWrapper/GitWorkingCopy.php
@@ -454,13 +454,13 @@ class GitWorkingCopy
     /**
      * Checks if the given remote exists.
      *
-     * @param string $remote
-     *   The remote to check.
+     * @param string $name
+     *   The name of the remote to check.
      *
      * @return bool
      */
-    public function hasRemote($remote) {
-        return array_key_exists($remote, $this->getRemotes());
+    public function hasRemote($name) {
+        return array_key_exists($name, $this->getRemotes());
     }
 
     /**

--- a/src/GitWrapper/GitWorkingCopy.php
+++ b/src/GitWrapper/GitWorkingCopy.php
@@ -378,6 +378,132 @@ class GitWorkingCopy
     }
 
     /**
+     * Adds a remote to the repository.
+     *
+     * @param string $name
+     *   The name of the remote to add.
+     * @param string $url
+     *   The URL of the remote to add.
+     * @param array $options
+     *   An associative array of options, with the following keys:
+     *   - -f: Boolean, set to true to run git fetch immediately after the
+     *     remote is set up. Defaults to false.
+     *   - --tags: Boolean, set to true to import every tag from the remote
+     *     repository when git fetch is run. Defaults to false.
+     *   - --no-tags: Boolean, when set to true, git fetch does not import tags
+     *     from the remote repository. Defaults to false.
+     *   - -t: Optional array of branch names to track. If left empty, all
+     *     branches will be tracked.
+     *   - -m: Optional name of the master branch to track. This will set up a
+     *     symbolic ref 'refs/remotes/<name>/HEAD which points at the specified
+     *     master branch on the remote. When omitted, no symbolic ref will be
+     *     created.
+     *
+     * @return \GitWrapper\GitWorkingCopy
+     *
+     * @throws \GitWrapper\GitException
+     *   Thrown when the name or URL are missing.
+     */
+    public function addRemote($name, $url, $options = array()) {
+        if (empty($name)) {
+            throw new GitException('Cannot add remote without a name.');
+        }
+        if (empty($url)) {
+            throw new GitException('Cannot add remote without a URL.');
+        }
+
+        $args = array('add');
+
+        // Add boolean options.
+        foreach (array('-f', '--tags', '--no-tags') as $option) {
+            if (!empty($options[$option])) {
+                $args[] = $option;
+            }
+        }
+
+        // Add tracking branches.
+        if (!empty($options['-t'])) {
+            foreach ($options['-t'] as $branch) {
+                array_push($args, '-t', $branch);
+            }
+        }
+
+        // Add master branch.
+        if (!empty($options['-m'])) {
+            array_push($args, '-m', $options['-m']);
+        }
+
+        // Add remote name and URL.
+        array_push($args, $name, $url);
+
+        return call_user_func_array(array($this, 'remote'), $args);
+    }
+
+    /**
+     * Removes the given remote.
+     *
+     * @param string $name
+     *   The name of the remote to remove.
+     *
+     * @return \GitWrapper\GitWorkingCopy
+     */
+    public function removeRemote($name) {
+        return $this->remote('rm', $name);
+    }
+
+    /**
+     * Checks if the given remote exists.
+     *
+     * @param string $remote
+     *   The remote to check.
+     *
+     * @return bool
+     */
+    public function hasRemote($remote) {
+        return array_key_exists($remote, $this->getRemotes());
+    }
+
+    /**
+     * Returns the given remote.
+     *
+     * @param string $name
+     *   The name of the remote.
+     *
+     * @return array
+     *   An associative array with the following keys:
+     *   - fetch: the fetch URL.
+     *   - push: the push URL.
+     *
+     * @throws \GitWrapper\GitException
+     *   Thrown when the remote does not exist.
+     */
+    public function getRemote($name) {
+        if (!$this->hasRemote($name)) {
+            throw new GitException('The remote "' . $name . '" does not exist.');
+        }
+        $remotes = $this->getRemotes();
+        return $remotes[$name];
+    }
+
+    /**
+     * Returns all existing remotes.
+     *
+     * @return array
+     *   An associative array, keyed by remote name, containing an associative
+     *   array with the following keys:
+     *   - fetch: the fetch URL.
+     *   - push: the push URL.
+     */
+    public function getRemotes() {
+        $remotes = array();
+        foreach (explode("\n", rtrim($this->remote()->getOutput())) as $remote) {
+            $remotes[$remote]['fetch'] = rtrim($this->remote('get-url', $remote)->getOutput());
+            $remotes[$remote]['push'] = rtrim($this->remote('get-url', '--push', $remote)->getOutput());
+        }
+        return $remotes;
+    }
+
+    /**
      * @} End of "defgroup command_helpers".
      */
 


### PR DESCRIPTION
It would be nice to have a few helper methods for common operations that can be done on remotes.

The PR adds the following methods:

* `addRemote($name, $url, $options)`
* `removeRemote($name)`
* `hasRemote($name)`
* `getRemote($name)`
* `getRemotes()`