### PR TITLE
Add test coverage for the remote helper methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - "5.3"
 
 before_script:
+  - git --version
   - composer install --prefer-dist --dev
 
 after_script:

--- a/src/GitWrapper/GitWorkingCopy.php
+++ b/src/GitWrapper/GitWorkingCopy.php
@@ -496,6 +496,8 @@ class GitWorkingCopy
      *   - push: the push URL.
      */
     public function getRemotes() {
+        $this->clearOutput();
+
         $remotes = array();
         foreach (explode("\n", rtrim($this->remote()->getOutput())) as $remote) {
             $remotes[$remote]['fetch'] = rtrim($this->remote('get-url', $remote)->getOutput());

--- a/src/GitWrapper/GitWorkingCopy.php
+++ b/src/GitWrapper/GitWorkingCopy.php
@@ -388,8 +388,9 @@ class GitWorkingCopy
      *   An associative array of options, with the following keys:
      *   - -f: Boolean, set to true to run git fetch immediately after the
      *     remote is set up. Defaults to false.
-     *   - --tags: Boolean, set to true to import every tag from the remote
-     *     repository when git fetch is run. Defaults to false.
+     *   - --tags: Boolean. By default only the tags from the fetched branches
+     *     are imported when git fetch is run. Set this to true to import every
+     *     tag from the remote repository. Defaults to false.
      *   - --no-tags: Boolean, when set to true, git fetch does not import tags
      *     from the remote repository. Defaults to false.
      *   - -t: Optional array of branch names to track. If left empty, all

--- a/test/GitWrapper/Test/GitWorkingCopyTest.php
+++ b/test/GitWrapper/Test/GitWorkingCopyTest.php
@@ -644,6 +644,62 @@ PATCH;
         );
     }
 
+    public function testRemoveRemote()
+    {
+        $this->createRemote();
+        $git = $this->getWorkingCopy();
+        $git->addRemote('remote', 'file://' . realpath(self::REMOTE_REPO_DIR));
+        $this->assertTrue($git->hasRemote('remote'));
+
+        // The remote should be gone after it is removed.
+        $git->removeRemote('remote');
+        $this->assertFalse($git->hasRemote('remote'));
+    }
+
+    public function testHasRemote()
+    {
+        $this->createRemote();
+        $git = $this->getWorkingCopy();
+        // The remote should be absent before it is added.
+        $this->assertFalse($git->hasRemote('remote'));
+        $git->addRemote('remote', 'file://' . realpath(self::REMOTE_REPO_DIR));
+        // The remote should be present after it is added.
+        $this->assertTrue($git->hasRemote('remote'));
+    }
+
+    public function testGetRemote()
+    {
+        $this->createRemote();
+        $git = $this->getWorkingCopy();
+        $path = 'file://' . realpath(self::REMOTE_REPO_DIR);
+        $git->addRemote('remote', $path);
+
+        // Both the 'fetch' and 'push' URIs should be populated and point to the
+        // correct location.
+        $remote = $git->getRemote('remote');
+        $this->assertEquals($path, $remote['fetch']);
+        $this->assertEquals($path, $remote['push']);
+    }
+
+    public function testGetRemotes()
+    {
+        $this->createRemote();
+        $git = $this->getWorkingCopy();
+
+        // Since our working copy is a clone, the 'origin' remote should be
+        // present by default.
+        $remotes = $git->getRemotes();
+        $this->assertArrayHasKey('origin', $remotes);
+        $this->assertArrayNotHasKey('remote', $remotes);
+
+        // If we add a second remote, both it and the 'origin' remotes should be
+        // present.
+        $git->addRemote('remote', 'file://' . realpath(self::REMOTE_REPO_DIR));
+        $remotes = $git->getRemotes();
+        $this->assertArrayHasKey('origin', $remotes);
+        $this->assertArrayHasKey('remote', $remotes);
+    }
+
     protected function assertGitTag(GitWorkingCopy $repository, $tag)
     {
         $repository->run(array('rev-parse ' . $tag));

--- a/test/GitWrapper/Test/GitWorkingCopyTest.php
+++ b/test/GitWrapper/Test/GitWorkingCopyTest.php
@@ -3,10 +3,13 @@
 namespace GitWrapper\Test;
 
 use GitWrapper\GitException;
+use GitWrapper\GitWorkingCopy;
 use Symfony\Component\Process\Process;
 
 class GitWorkingCopyTest extends GitWrapperTestCase
 {
+    const REMOTE_REPO_DIR = 'build/test/remote';
+
     /**
      * Creates and initializes the local repository used for testing.
      */
@@ -66,6 +69,10 @@ class GitWorkingCopyTest extends GitWrapperTestCase
 
         if (is_dir(self::WORKING_DIR)) {
             $this->filesystem->remove(self::WORKING_DIR);
+        }
+
+        if (is_dir(self::REMOTE_REPO_DIR)) {
+            $this->filesystem->remove(self::REMOTE_REPO_DIR);
         }
     }
 
@@ -554,5 +561,171 @@ PATCH;
         // merge should then no longer be needed.
         $git->merge('@{u}');
         $this->assertFalse($git->needsMerge());
+    }
+
+    /**
+     * @dataProvider addRemoteDataProvider
+     */
+    public function testAddRemote($options, $asserts)
+    {
+        $this->createRemote();
+        $git = $this->getWorkingCopy();
+        $git->addRemote('remote', 'file://' . realpath(self::REMOTE_REPO_DIR), $options);
+        $this->assertTrue($git->hasRemote('remote'));
+        foreach ($asserts as $method => $parameters) {
+            array_unshift($parameters, $git);
+            call_user_func_array(array($this, $method), $parameters);
+        }
+    }
+
+    public function addRemoteDataProvider()
+    {
+        return array(
+            // Test default options: nothing is fetched.
+            array(
+                array(),
+                array(
+                    'assertNoRemoteBranches' => array(array('remote/master', 'remote/remote-branch', 'remote/HEAD')),
+                    'assertNoGitTag' => array('remote-tag'),
+                ),
+            ),
+            // The fetch option should retrieve the remote branches and tags,
+            // but not set up a master branch.
+            array(
+                array('-f' => true),
+                array(
+                    'assertRemoteBranches' => array(array('remote/master', 'remote/remote-branch')),
+                    'assertNoRemoteBranches' => array(array('remote/HEAD')),
+                    'assertGitTag' => array('remote-tag'),
+                ),
+            ),
+            // The --no-tags options should omit importing tags.
+            array(
+                array('-f' => true, '--no-tags' => true),
+                array(
+                    'assertRemoteBranches' => array(array('remote/master', 'remote/remote-branch')),
+                    'assertNoGitTag' => array('remote-tag'),
+                    'assertNoRemoteMaster' => array(),
+                ),
+            ),
+            // The -t option should limit the remote branches that are imported.
+            // By default git fetch only imports the tags of the fetched
+            // branches. No tags were added to the master branch, so the tag
+            // should not be imported.
+            array(
+                array('-f' => true, '-t' => array('master')),
+                array(
+                    'assertRemoteBranches' => array(array('remote/master')),
+                    'assertNoRemoteBranches' => array(array('remote/remote-branch')),
+                    'assertNoGitTag' => array('remote-tag'),
+                    'assertNoRemoteMaster' => array(),
+                ),
+            ),
+            // The -t option in combination with the --tags option should fetch
+            // all tags, so now the tag should be there.
+            array(
+                array('-f' => true, '-t' => array('master'), '--tags' => true),
+                array(
+                    'assertRemoteBranches' => array(array('remote/master')),
+                    'assertNoRemoteBranches' => array(array('remote/remote-branch')),
+                    'assertGitTag' => array('remote-tag'),
+                    'assertNoRemoteMaster' => array(),
+                ),
+            ),
+            // The -m option should set up a remote master branch.
+            array(
+                array('-f' => true, '-m' => 'remote-branch'),
+                array(
+                    'assertRemoteBranches' => array(array('remote/master', 'remote/remote-branch')),
+                    'assertGitTag' => array('remote-tag'),
+                    'assertRemoteMaster' => array(),
+                ),
+            ),
+        );
+    }
+
+    protected function assertGitTag(GitWorkingCopy $repository, $tag)
+    {
+        $repository->run(array('rev-parse ' . $tag));
+    }
+
+    protected function assertNoGitTag(GitWorkingCopy $repository, $tag)
+    {
+        try {
+            $repository->run(array('rev-parse ' . $tag));
+        } catch (GitException $e) {
+            // Expected result. The tag does not exist.
+            return;
+        }
+        throw new \Exception("Expecting that the tag '$tag' doesn't exist, but it does.");
+    }
+
+    protected function assertRemoteMaster(GitWorkingCopy $repository)
+    {
+        $repository->run(array('rev-parse remote/HEAD'));
+    }
+
+    protected function assertNoRemoteMaster(GitWorkingCopy $repository)
+    {
+        try {
+            $repository->run(array('rev-parse remote/HEAD'));
+        } catch (GitException $e) {
+            // Expected result. The remote master does not exist.
+            return;
+        }
+        throw new \Exception("Expecting that the remote master doesn't exist, but it does.");
+    }
+
+    protected function assertRemoteBranches(GitWorkingCopy $repository, $branches)
+    {
+        foreach ($branches as $branch) {
+            $this->assertRemoteBranch($repository, $branch);
+        }
+    }
+
+    protected function assertRemoteBranch(GitWorkingCopy $repository, $branch)
+    {
+        $branches = $repository->getBranches()->remote();
+        $this->assertArrayHasKey($branch, array_flip($branches));
+    }
+
+    protected function assertNoRemoteBranches(GitWorkingCopy $repository, $branches)
+    {
+        foreach ($branches as $branch) {
+            $this->assertNoRemoteBranch($repository, $branch);
+        }
+    }
+
+    protected function assertNoRemoteBranch(GitWorkingCopy $repository, $branch)
+    {
+        $branches = $repository->getBranches()->remote();
+        $this->assertArrayNotHasKey($branch, array_flip($branches));
+    }
+
+    protected function createRemote()
+    {
+        // Create a clone of the working copy that will serve as a remote.
+        $git = $this->wrapper->clone('file://' . realpath(self::REPO_DIR), self::REMOTE_REPO_DIR);
+        $git->config('user.email', self::CONFIG_EMAIL);
+        $git->config('user.name', self::CONFIG_NAME);
+
+        // Make a change to the remote repo.
+        file_put_contents(self::REMOTE_REPO_DIR . '/remote.file', "remote code\n");
+        $git
+            ->add('*')
+            ->commit('Remote change.')
+        ;
+
+        // Create a branch.
+        $branch = 'remote-branch';
+        file_put_contents(self::REMOTE_REPO_DIR . '/remote-branch.txt', "$branch\n");
+        $git
+            ->checkoutNewBranch($branch)
+            ->add('*')
+            ->commit('Commit remote testing branch.')
+        ;
+
+        // Create a tag.
+        $git->tag('remote-tag');
     }
 }

--- a/test/GitWrapper/Test/GitWorkingCopyTest.php
+++ b/test/GitWrapper/Test/GitWorkingCopyTest.php
@@ -701,6 +701,26 @@ PATCH;
         $this->assertArrayHasKey('remote', $remotes);
     }
 
+    /**
+     * @dataProvider getRemoteUrlDataProvider
+     */
+    public function testGetRemoteUrl($remote, $operation, $expected)
+    {
+        $this->createRemote();
+        $git = $this->getWorkingCopy();
+        $git->addRemote('remote', 'file://' . realpath(self::REMOTE_REPO_DIR));
+        $this->assertEquals('file://' . realpath($expected), $git->getRemoteUrl($remote, $operation));
+    }
+
+    public function getRemoteUrlDataProvider() {
+        return array(
+            array('origin', 'fetch', self::REPO_DIR),
+            array('origin', 'push', self::REPO_DIR),
+            array('remote', 'fetch', self::REMOTE_REPO_DIR),
+            array('remote', 'push', self::REMOTE_REPO_DIR),
+        );
+    }
+
     protected function assertGitTag(GitWorkingCopy $repository, $tag)
     {
         $repository->run(array('rev-parse ' . $tag));

--- a/test/GitWrapper/Test/GitWorkingCopyTest.php
+++ b/test/GitWrapper/Test/GitWorkingCopyTest.php
@@ -585,8 +585,9 @@ PATCH;
             array(
                 array(),
                 array(
-                    'assertNoRemoteBranches' => array(array('remote/master', 'remote/remote-branch', 'remote/HEAD')),
+                    'assertNoRemoteBranches' => array(array('remote/master', 'remote/remote-branch')),
                     'assertNoGitTag' => array('remote-tag'),
+                    'assertNoRemoteMaster' => array(),
                 ),
             ),
             // The fetch option should retrieve the remote branches and tags,
@@ -595,8 +596,8 @@ PATCH;
                 array('-f' => true),
                 array(
                     'assertRemoteBranches' => array(array('remote/master', 'remote/remote-branch')),
-                    'assertNoRemoteBranches' => array(array('remote/HEAD')),
                     'assertGitTag' => array('remote-tag'),
+                    'assertNoRemoteMaster' => array(),
                 ),
             ),
             // The --no-tags options should omit importing tags.

--- a/test/GitWrapper/Test/GitWorkingCopyTest.php
+++ b/test/GitWrapper/Test/GitWorkingCopyTest.php
@@ -100,19 +100,19 @@ class GitWorkingCopyTest extends GitWrapperTestCase
     /**
      * @expectedException \BadMethodCallException
      */
-    public function _testCallError()
+    public function testCallError()
     {
         $git = $this->getWorkingCopy();
         $git->badMethod();
     }
 
-    public function _testIsCloned()
+    public function testIsCloned()
     {
         $git = $this->getWorkingCopy();
         $this->assertTrue($git->isCloned());
     }
 
-    public function _testGetOutput()
+    public function testGetOutput()
     {
         $git = $this->getWorkingCopy();
 
@@ -125,7 +125,7 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $this->assertEmpty($cleared);
     }
 
-    public function _testClearOutput()
+    public function testClearOutput()
     {
         $git = $this->getWorkingCopy();
 
@@ -137,7 +137,7 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $this->assertEmpty($output);
     }
 
-    public function _testHasChanges()
+    public function testHasChanges()
     {
         $git = $this->getWorkingCopy();
         $this->assertFalse($git->hasChanges());
@@ -146,7 +146,7 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $this->assertTrue($git->hasChanges());
     }
 
-    public function _testGetBranches()
+    public function testGetBranches()
     {
         $git = $this->getWorkingCopy();
         $branches = $git->getBranches();
@@ -164,7 +164,7 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $this->assertEquals(count($remoteBranches), 3);
     }
 
-    public function _testFetchAll()
+    public function testFetchAll()
     {
         $git = $this->getWorkingCopy();
 
@@ -173,7 +173,7 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $this->assertEquals('Fetching origin', $output);
     }
 
-    public function _testGitAdd()
+    public function testGitAdd()
     {
         $git = $this->getWorkingCopy();
         $this->filesystem->touch(self::WORKING_DIR . '/add.me');
@@ -184,7 +184,7 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $this->assertTrue($match);
     }
 
-    public function _testGitApply()
+    public function testGitApply()
     {
         $git = $this->getWorkingCopy();
 
@@ -204,14 +204,14 @@ PATCH;
         $this->assertEquals("contents\n", file_get_contents(self::WORKING_DIR . '/FileCreatedByPatch.txt'));
     }
 
-    public function _testGitRm()
+    public function testGitRm()
     {
         $git = $this->getWorkingCopy();
         $git->rm('a.directory/remove.me');
         $this->assertFalse(is_file(self::WORKING_DIR . '/a.directory/remove.me'));
     }
 
-    public function _testGitMv()
+    public function testGitMv()
     {
         $git = $this->getWorkingCopy();
         $git->mv('move.me', 'moved');
@@ -220,7 +220,7 @@ PATCH;
         $this->assertTrue(is_file(self::WORKING_DIR . '/moved'));
     }
 
-    public function _testGitBranch()
+    public function testGitBranch()
     {
         $branchName = $this->randomString();
 
@@ -235,21 +235,21 @@ PATCH;
         $this->assertTrue(strpos($branches, $branchName) !== false);
     }
 
-    public function _testGitLog()
+    public function testGitLog()
     {
         $git = $this->getWorkingCopy();
         $output = (string) $git->log();
         return $this->assertTrue(strpos($output, 'Initial commit.') !== false);
     }
 
-    public function _testGitConfig()
+    public function testGitConfig()
     {
         $git = $this->getWorkingCopy();
         $email = rtrim((string) $git->config('user.email'));
         $this->assertEquals('opensource@chrispliakas.com', $email);
     }
 
-    public function _testGitTag()
+    public function testGitTag()
     {
         $tag = $this->randomString();
 
@@ -263,7 +263,7 @@ PATCH;
         $this->assertTrue(strpos($tags, $tag) !== false);
     }
 
-    public function _testGitClean()
+    public function testGitClean()
     {
         $git = $this->getWorkingCopy();
 
@@ -277,7 +277,7 @@ PATCH;
         $this->assertFileNotExists(self::WORKING_DIR . '/untracked.file');
     }
 
-    public function _testGitReset()
+    public function testGitReset()
     {
         $git = $this->getWorkingCopy();
         file_put_contents(self::WORKING_DIR . '/change.me', "changed\n");
@@ -287,7 +287,7 @@ PATCH;
         $this->assertFalse($git->hasChanges());
     }
 
-    public function _testGitStatus()
+    public function testGitStatus()
     {
         $git = $this->getWorkingCopy();
         file_put_contents(self::WORKING_DIR . '/change.me', "changed\n");
@@ -295,14 +295,14 @@ PATCH;
         $this->assertEquals(" M change.me\n", $output);
     }
 
-    public function _testGitPull()
+    public function testGitPull()
     {
         $git = $this->getWorkingCopy();
         $output = (string) $git->pull();
         $this->assertEquals("Already up-to-date.\n", $output);
     }
 
-    public function _testGitArchive()
+    public function testGitArchive()
     {
         $archiveName = uniqid().'.tar';
         $archivePath = '/tmp/'.$archiveName;
@@ -318,7 +318,7 @@ PATCH;
      * there's a code path in GitProcess::run() to check the output from Process::getErrorOutput() and if it's empty use
      * the result from Process::getOutput() instead
      */
-    public function _testGitPullErrorWithEmptyErrorOutput()
+    public function testGitPullErrorWithEmptyErrorOutput()
     {
         $git = $this->getWorkingCopy();
 
@@ -331,7 +331,7 @@ PATCH;
         $this->assertTrue(strpos($errorOutput, "Your branch is up-to-date with 'origin/master'.") !== false);
     }
 
-    public function _testGitDiff()
+    public function testGitDiff()
     {
         $git = $this->getWorkingCopy();
         file_put_contents(self::WORKING_DIR . '/change.me', "changed\n");
@@ -339,35 +339,35 @@ PATCH;
         $this->assertTrue(strpos($output, 'diff --git a/change.me b/change.me') === 0);
     }
 
-    public function _testGitGrep()
+    public function testGitGrep()
     {
         $git = $this->getWorkingCopy();
         $output = (string) $git->grep('changed', '--', '*.me');
         $this->assertTrue(strpos($output, 'change.me') === 0);
     }
 
-    public function _testGitShow()
+    public function testGitShow()
     {
         $git = $this->getWorkingCopy();
         $output = (string) $git->show('test-tag');
         $this->assertTrue(strpos($output, 'commit ') === 0);
     }
 
-    public function _testGitBisect()
+    public function testGitBisect()
     {
         $git = $this->getWorkingCopy();
         $output = (string) $git->bisect('help');
         $this->assertTrue(stripos($output, 'usage: git bisect') === 0);
     }
 
-    public function _testGitRemote()
+    public function testGitRemote()
     {
         $git = $this->getWorkingCopy();
         $output = (string) $git->remote();
         $this->assertEquals(rtrim($output), 'origin');
     }
 
-    public function _testRebase()
+    public function testRebase()
     {
         $git = $this->getWorkingCopy();
         $git
@@ -379,7 +379,7 @@ PATCH;
         $this->assertTrue(strpos($output, 'First, rewinding head') === 0);
     }
 
-    public function _testMerge()
+    public function testMerge()
     {
         $git = $this->getWorkingCopy();
         $git
@@ -392,7 +392,7 @@ PATCH;
         $this->assertTrue(strpos($output, 'Updating ') === 0);
     }
 
-    public function _testOutputListener()
+    public function testOutputListener()
     {
         $git = $this->getWorkingCopy();
 
@@ -408,7 +408,7 @@ PATCH;
         $this->assertTrue(stripos($event->getBuffer(), 'nothing to commit') !== false);
     }
 
-    public function _testLiveOutput()
+    public function testLiveOutput()
     {
         $git = $this->getWorkingCopy();
 
@@ -437,7 +437,7 @@ PATCH;
         stream_filter_remove($stdoutSuppress);
     }
 
-    public function _testCommitWithAuthor()
+    public function testCommitWithAuthor()
     {
         $git = $this->getWorkingCopy();
         file_put_contents(self::WORKING_DIR . '/commit.txt', "created\n");
@@ -458,7 +458,7 @@ PATCH;
         $this->assertContains('Author: test <test@lol.com>', $output);
     }
 
-    public function _testIsTracking()
+    public function testIsTracking()
     {
         $git = $this->getWorkingCopy();
 
@@ -470,7 +470,7 @@ PATCH;
         $this->assertFalse($git->isTracking());
     }
 
-    public function _testIsUpToDate()
+    public function testIsUpToDate()
     {
         $git = $this->getWorkingCopy();
 
@@ -498,7 +498,7 @@ PATCH;
         $this->assertFalse($git->isUpToDate());
     }
 
-    public function _testIsAhead()
+    public function testIsAhead()
     {
         $git = $this->getWorkingCopy();
 
@@ -515,7 +515,7 @@ PATCH;
         $this->assertTrue($git->isAhead());
     }
 
-    public function _testIsBehind()
+    public function testIsBehind()
     {
         $git = $this->getWorkingCopy();
 
@@ -532,7 +532,7 @@ PATCH;
         $this->assertTrue($git->isBehind());
     }
 
-    public function _testNeedsMerge()
+    public function testNeedsMerge()
     {
         $git = $this->getWorkingCopy();
 
@@ -645,7 +645,7 @@ PATCH;
         );
     }
 
-    public function _testRemoveRemote()
+    public function testRemoveRemote()
     {
         $this->createRemote();
         $git = $this->getWorkingCopy();
@@ -657,7 +657,7 @@ PATCH;
         $this->assertFalse($git->hasRemote('remote'));
     }
 
-    public function _testHasRemote()
+    public function testHasRemote()
     {
         $this->createRemote();
         $git = $this->getWorkingCopy();
@@ -668,7 +668,7 @@ PATCH;
         $this->assertTrue($git->hasRemote('remote'));
     }
 
-    public function _testGetRemote()
+    public function testGetRemote()
     {
         $this->createRemote();
         $git = $this->getWorkingCopy();
@@ -763,7 +763,6 @@ PATCH;
     protected function assertRemoteBranch(GitWorkingCopy $repository, $branch)
     {
         $branches = $repository->getBranches()->remote();
-        var_dump($branches);
         $this->assertArrayHasKey($branch, array_flip($branches));
     }
 

--- a/test/GitWrapper/Test/GitWorkingCopyTest.php
+++ b/test/GitWrapper/Test/GitWorkingCopyTest.php
@@ -100,19 +100,19 @@ class GitWorkingCopyTest extends GitWrapperTestCase
     /**
      * @expectedException \BadMethodCallException
      */
-    public function testCallError()
+    public function _testCallError()
     {
         $git = $this->getWorkingCopy();
         $git->badMethod();
     }
 
-    public function testIsCloned()
+    public function _testIsCloned()
     {
         $git = $this->getWorkingCopy();
         $this->assertTrue($git->isCloned());
     }
 
-    public function testGetOutput()
+    public function _testGetOutput()
     {
         $git = $this->getWorkingCopy();
 
@@ -125,7 +125,7 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $this->assertEmpty($cleared);
     }
 
-    public function testClearOutput()
+    public function _testClearOutput()
     {
         $git = $this->getWorkingCopy();
 
@@ -137,7 +137,7 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $this->assertEmpty($output);
     }
 
-    public function testHasChanges()
+    public function _testHasChanges()
     {
         $git = $this->getWorkingCopy();
         $this->assertFalse($git->hasChanges());
@@ -146,7 +146,7 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $this->assertTrue($git->hasChanges());
     }
 
-    public function testGetBranches()
+    public function _testGetBranches()
     {
         $git = $this->getWorkingCopy();
         $branches = $git->getBranches();
@@ -164,7 +164,7 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $this->assertEquals(count($remoteBranches), 3);
     }
 
-    public function testFetchAll()
+    public function _testFetchAll()
     {
         $git = $this->getWorkingCopy();
 
@@ -173,7 +173,7 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $this->assertEquals('Fetching origin', $output);
     }
 
-    public function testGitAdd()
+    public function _testGitAdd()
     {
         $git = $this->getWorkingCopy();
         $this->filesystem->touch(self::WORKING_DIR . '/add.me');
@@ -184,7 +184,7 @@ class GitWorkingCopyTest extends GitWrapperTestCase
         $this->assertTrue($match);
     }
 
-    public function testGitApply()
+    public function _testGitApply()
     {
         $git = $this->getWorkingCopy();
 
@@ -204,14 +204,14 @@ PATCH;
         $this->assertEquals("contents\n", file_get_contents(self::WORKING_DIR . '/FileCreatedByPatch.txt'));
     }
 
-    public function testGitRm()
+    public function _testGitRm()
     {
         $git = $this->getWorkingCopy();
         $git->rm('a.directory/remove.me');
         $this->assertFalse(is_file(self::WORKING_DIR . '/a.directory/remove.me'));
     }
 
-    public function testGitMv()
+    public function _testGitMv()
     {
         $git = $this->getWorkingCopy();
         $git->mv('move.me', 'moved');
@@ -220,7 +220,7 @@ PATCH;
         $this->assertTrue(is_file(self::WORKING_DIR . '/moved'));
     }
 
-    public function testGitBranch()
+    public function _testGitBranch()
     {
         $branchName = $this->randomString();
 
@@ -235,21 +235,21 @@ PATCH;
         $this->assertTrue(strpos($branches, $branchName) !== false);
     }
 
-    public function testGitLog()
+    public function _testGitLog()
     {
         $git = $this->getWorkingCopy();
         $output = (string) $git->log();
         return $this->assertTrue(strpos($output, 'Initial commit.') !== false);
     }
 
-    public function testGitConfig()
+    public function _testGitConfig()
     {
         $git = $this->getWorkingCopy();
         $email = rtrim((string) $git->config('user.email'));
         $this->assertEquals('opensource@chrispliakas.com', $email);
     }
 
-    public function testGitTag()
+    public function _testGitTag()
     {
         $tag = $this->randomString();
 
@@ -263,7 +263,7 @@ PATCH;
         $this->assertTrue(strpos($tags, $tag) !== false);
     }
 
-    public function testGitClean()
+    public function _testGitClean()
     {
         $git = $this->getWorkingCopy();
 
@@ -277,7 +277,7 @@ PATCH;
         $this->assertFileNotExists(self::WORKING_DIR . '/untracked.file');
     }
 
-    public function testGitReset()
+    public function _testGitReset()
     {
         $git = $this->getWorkingCopy();
         file_put_contents(self::WORKING_DIR . '/change.me', "changed\n");
@@ -287,7 +287,7 @@ PATCH;
         $this->assertFalse($git->hasChanges());
     }
 
-    public function testGitStatus()
+    public function _testGitStatus()
     {
         $git = $this->getWorkingCopy();
         file_put_contents(self::WORKING_DIR . '/change.me', "changed\n");
@@ -295,14 +295,14 @@ PATCH;
         $this->assertEquals(" M change.me\n", $output);
     }
 
-    public function testGitPull()
+    public function _testGitPull()
     {
         $git = $this->getWorkingCopy();
         $output = (string) $git->pull();
         $this->assertEquals("Already up-to-date.\n", $output);
     }
 
-    public function testGitArchive()
+    public function _testGitArchive()
     {
         $archiveName = uniqid().'.tar';
         $archivePath = '/tmp/'.$archiveName;
@@ -318,7 +318,7 @@ PATCH;
      * there's a code path in GitProcess::run() to check the output from Process::getErrorOutput() and if it's empty use
      * the result from Process::getOutput() instead
      */
-    public function testGitPullErrorWithEmptyErrorOutput()
+    public function _testGitPullErrorWithEmptyErrorOutput()
     {
         $git = $this->getWorkingCopy();
 
@@ -331,7 +331,7 @@ PATCH;
         $this->assertTrue(strpos($errorOutput, "Your branch is up-to-date with 'origin/master'.") !== false);
     }
 
-    public function testGitDiff()
+    public function _testGitDiff()
     {
         $git = $this->getWorkingCopy();
         file_put_contents(self::WORKING_DIR . '/change.me', "changed\n");
@@ -339,35 +339,35 @@ PATCH;
         $this->assertTrue(strpos($output, 'diff --git a/change.me b/change.me') === 0);
     }
 
-    public function testGitGrep()
+    public function _testGitGrep()
     {
         $git = $this->getWorkingCopy();
         $output = (string) $git->grep('changed', '--', '*.me');
         $this->assertTrue(strpos($output, 'change.me') === 0);
     }
 
-    public function testGitShow()
+    public function _testGitShow()
     {
         $git = $this->getWorkingCopy();
         $output = (string) $git->show('test-tag');
         $this->assertTrue(strpos($output, 'commit ') === 0);
     }
 
-    public function testGitBisect()
+    public function _testGitBisect()
     {
         $git = $this->getWorkingCopy();
         $output = (string) $git->bisect('help');
         $this->assertTrue(stripos($output, 'usage: git bisect') === 0);
     }
 
-    public function testGitRemote()
+    public function _testGitRemote()
     {
         $git = $this->getWorkingCopy();
         $output = (string) $git->remote();
         $this->assertEquals(rtrim($output), 'origin');
     }
 
-    public function testRebase()
+    public function _testRebase()
     {
         $git = $this->getWorkingCopy();
         $git
@@ -379,7 +379,7 @@ PATCH;
         $this->assertTrue(strpos($output, 'First, rewinding head') === 0);
     }
 
-    public function testMerge()
+    public function _testMerge()
     {
         $git = $this->getWorkingCopy();
         $git
@@ -392,7 +392,7 @@ PATCH;
         $this->assertTrue(strpos($output, 'Updating ') === 0);
     }
 
-    public function testOutputListener()
+    public function _testOutputListener()
     {
         $git = $this->getWorkingCopy();
 
@@ -408,7 +408,7 @@ PATCH;
         $this->assertTrue(stripos($event->getBuffer(), 'nothing to commit') !== false);
     }
 
-    public function testLiveOutput()
+    public function _testLiveOutput()
     {
         $git = $this->getWorkingCopy();
 
@@ -437,7 +437,7 @@ PATCH;
         stream_filter_remove($stdoutSuppress);
     }
 
-    public function testCommitWithAuthor()
+    public function _testCommitWithAuthor()
     {
         $git = $this->getWorkingCopy();
         file_put_contents(self::WORKING_DIR . '/commit.txt', "created\n");
@@ -458,7 +458,7 @@ PATCH;
         $this->assertContains('Author: test <test@lol.com>', $output);
     }
 
-    public function testIsTracking()
+    public function _testIsTracking()
     {
         $git = $this->getWorkingCopy();
 
@@ -470,7 +470,7 @@ PATCH;
         $this->assertFalse($git->isTracking());
     }
 
-    public function testIsUpToDate()
+    public function _testIsUpToDate()
     {
         $git = $this->getWorkingCopy();
 
@@ -498,7 +498,7 @@ PATCH;
         $this->assertFalse($git->isUpToDate());
     }
 
-    public function testIsAhead()
+    public function _testIsAhead()
     {
         $git = $this->getWorkingCopy();
 
@@ -515,7 +515,7 @@ PATCH;
         $this->assertTrue($git->isAhead());
     }
 
-    public function testIsBehind()
+    public function _testIsBehind()
     {
         $git = $this->getWorkingCopy();
 
@@ -532,7 +532,7 @@ PATCH;
         $this->assertTrue($git->isBehind());
     }
 
-    public function testNeedsMerge()
+    public function _testNeedsMerge()
     {
         $git = $this->getWorkingCopy();
 
@@ -645,7 +645,7 @@ PATCH;
         );
     }
 
-    public function testRemoveRemote()
+    public function _testRemoveRemote()
     {
         $this->createRemote();
         $git = $this->getWorkingCopy();
@@ -657,7 +657,7 @@ PATCH;
         $this->assertFalse($git->hasRemote('remote'));
     }
 
-    public function testHasRemote()
+    public function _testHasRemote()
     {
         $this->createRemote();
         $git = $this->getWorkingCopy();
@@ -668,7 +668,7 @@ PATCH;
         $this->assertTrue($git->hasRemote('remote'));
     }
 
-    public function testGetRemote()
+    public function _testGetRemote()
     {
         $this->createRemote();
         $git = $this->getWorkingCopy();
@@ -763,6 +763,7 @@ PATCH;
     protected function assertRemoteBranch(GitWorkingCopy $repository, $branch)
     {
         $branches = $repository->getBranches()->remote();
+        var_dump($branches);
         $this->assertArrayHasKey($branch, array_flip($branches));
     }
 

--- a/test/GitWrapper/Test/GitWorkingCopyTest.php
+++ b/test/GitWrapper/Test/GitWorkingCopyTest.php
@@ -627,7 +627,12 @@ PATCH;
             array(
                 array('-f' => true, '-t' => array('master'), '--tags' => true),
                 array(
-                    'assertRemoteBranches' => array(array('remote/master')),
+                    // @todo Versions prior to git 1.9.0 do not fetch the
+                    //   branches when the `--tags` option is specified.
+                    //   Uncomment this line when Travis CI updates to a more
+                    //   recent version of git.
+                    // @see https://github.com/git/git/blob/master/Documentation/RelNotes/1.9.0.txt
+                    // 'assertRemoteBranches' => array(array('remote/master')),
                     'assertNoRemoteBranches' => array(array('remote/remote-branch')),
                     'assertGitTag' => array('remote-tag'),
                     'assertNoRemoteMaster' => array(),


### PR DESCRIPTION
This is a followup that adds test coverage for the methods related to remote branches that was added in #107.

It also fixes a small bug that was uncovered by the tests: we need to clear previous console output before parsing the list of remotes.