### PR TITLE
travis: bump to PHP 7.0, misc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: php
 
 php:
+  - 7.2
   - 7.1
   - 7.0
-  - 5.6
-  - 5.5
-  - 5.4
-  - 5.3
-
+  
 before_script:
   - git --version
-  - composer install --prefer-dist --dev
+  - composer install --prefer-dist
+  
+script:
+  - vendor/bin/phpunit
 
 after_script:
   - vendor/bin/ocular code-coverage:upload --format=php-clover build/logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ php:
   - 7.1
   - 7.0
   
+matrix:
+  allow_failures:
+    - php: 7.2
+
 before_script:
   - git --version
   - composer install --prefer-dist


### PR DESCRIPTION
To keep this package alive, it's neccessary to focus on updating.
Most packages in PHP [go to PHP 7.1](https://gophp71.org/), so this one should do at least PHP 7.0

The `--dev` option is on by default now
