### PR TITLE
Refactoring tests

### DIFF
--- a/tests/GitLoggerListenerTest.php
+++ b/tests/GitLoggerListenerTest.php
@@ -2,6 +2,7 @@
 
 namespace GitWrapper\Test;
 
+use DomainException;
 use GitWrapper\Event\GitLoggerListener;
 use GitWrapper\GitCommand;
 use Psr\Log\LogLevel;
@@ -33,11 +34,9 @@ final class GitLoggerListenerTest extends AbstractGitWrapperTestCase
         $this->assertSame('test-level', $listener->getLogLevelMapping('test.event'));
     }
 
-    /**
-     * @expectedException \DomainException
-     */
     public function testGetInvalidLogLevelMapping(): void
     {
+        $this->expectException(DomainException::class);
         $listener = new GitLoggerListener(new NullLogger());
         $listener->getLogLevelMapping('bad.event');
     }

--- a/tests/GitWorkingCopyTest.php
+++ b/tests/GitWorkingCopyTest.php
@@ -107,7 +107,7 @@ final class GitWorkingCopyTest extends AbstractGitWrapperTestCase
 
         // Test getting output of a simple status command.
         $output = $git->status();
-        $this->assertTrue(strpos($output, 'nothing to commit') !== false);
+        $this->assertContains('nothing to commit', $output);
     }
 
     public function testHasChanges(): void
@@ -175,7 +175,7 @@ PATCH;
         file_put_contents(self::WORKING_DIR . '/patch.txt', $patch);
         $git->apply('patch.txt');
         $this->assertRegExp('@\?\?\\s+FileCreatedByPatch\\.txt@s', $git->getStatus());
-        $this->assertSame("contents\n", file_get_contents(self::WORKING_DIR . '/FileCreatedByPatch.txt'));
+        $this->assertStringEqualsFile(self::WORKING_DIR . '/FileCreatedByPatch.txt', "contents\n");
     }
 
     public function testGitRm(): void
@@ -206,14 +206,14 @@ PATCH;
         $branches = $git->branch();
 
         // Check that our branch is there.
-        $this->assertTrue(strpos($branches, $branchName) !== false);
+        $this->assertContains($branchName, $branches);
     }
 
     public function testGitLog(): void
     {
         $git = $this->getWorkingCopy();
         $output = $git->log();
-        $this->assertTrue(strpos($output, 'Initial commit.') !== false);
+        $this->assertContains('Initial commit.', $output);
     }
 
     public function testGitConfig(): void
@@ -232,7 +232,7 @@ PATCH;
         $git->pushTag($tag);
 
         $tags = $git->tag();
-        $this->assertTrue(strpos($tags, $tag) !== false);
+        $this->assertContains($tag, $tags);
     }
 
     public function testGitClean(): void
@@ -301,35 +301,35 @@ PATCH;
         $git = $this->getWorkingCopy();
         file_put_contents(self::WORKING_DIR . '/change.me', "changed\n");
         $output = $git->diff();
-        $this->assertTrue(strpos($output, 'diff --git a/change.me b/change.me') === 0);
+        $this->assertStringStartsWith('diff --git a/change.me b/change.me', $output);
     }
 
     public function testGitGrep(): void
     {
         $git = $this->getWorkingCopy();
         $output = $git->grep('changed', '--', '*.me');
-        $this->assertTrue(strpos($output, 'change.me') === 0);
+        $this->assertStringStartsWith('change.me', $output);
     }
 
     public function testGitShow(): void
     {
         $git = $this->getWorkingCopy();
         $output = $git->show('test-tag');
-        $this->assertTrue(strpos($output, 'commit ') === 0);
+        $this->assertStringStartsWith('commit ', $output);
     }
 
     public function testGitBisect(): void
     {
         $git = $this->getWorkingCopy();
         $output = $git->bisect('help');
-        $this->assertTrue(stripos($output, 'usage: git bisect') === 0);
+        $this->assertStringStartsWith('usage: git bisect', $output);
     }
 
     public function testGitRemote(): void
     {
         $git = $this->getWorkingCopy();
         $output = $git->remote();
-        $this->assertSame(rtrim($output), 'origin');
+        $this->assertSame('origin', rtrim($output));
     }
 
     public function testRebase(): void
@@ -338,7 +338,7 @@ PATCH;
         $git->checkout('test-branch');
 
         $output = $git->rebase('test-branch', 'master');
-        $this->assertTrue(strpos($output, 'First, rewinding head') === 0);
+        $this->assertStringStartsWith('First, rewinding head', $output);
     }
 
     public function testMerge(): void
@@ -348,7 +348,7 @@ PATCH;
         $git->checkout('master');
 
         $output = $git->merge('test-branch');
-        $this->assertTrue(strpos($output, 'Updating ') === 0);
+        $this->assertStringStartsWith('Updating ', $output);
     }
 
     public function testOutputListener(): void
@@ -364,7 +364,7 @@ PATCH;
         $expectedType = Process::OUT;
         $this->assertSame($expectedType, $event->getType());
 
-        $this->assertTrue(stripos($event->getBuffer(), 'nothing to commit') !== false);
+        $this->assertContains('nothing to commit', $event->getBuffer());
     }
 
     public function testLiveOutput(): void
@@ -382,7 +382,7 @@ PATCH;
         $contents = ob_get_contents();
         ob_end_clean();
 
-        $this->assertTrue(stripos($contents, 'nothing to commit') !== false);
+        $this->assertContains('nothing to commit', $contents);
 
         $git->getWrapper()->streamOutput(false);
         ob_start();

--- a/tests/GitWrapperTest.php
+++ b/tests/GitWrapperTest.php
@@ -3,6 +3,7 @@
 namespace GitWrapper\Test;
 
 use GitWrapper\GitCommand;
+use GitWrapper\GitException;
 use GitWrapper\GitWorkingCopy;
 use GitWrapper\GitWrapper;
 use GitWrapper\Test\Event\TestDispatcher;
@@ -85,20 +86,16 @@ final class GitWrapperTest extends AbstractGitWrapperTestCase
         $this->assertSame($sshWrapperExpected, $this->gitWrapper->getEnvVar('GIT_SSH'));
     }
 
-    /**
-     * @expectedException \GitWrapper\GitException
-     */
     public function testSetPrivateKeyError(): void
     {
+        $this->expectException(GitException::class);
         $badKey = './tests/id_rsa_bad';
         $this->gitWrapper->setPrivateKey($badKey);
     }
 
-    /**
-     * @expectedException \GitWrapper\GitException
-     */
     public function testSetPrivateKeyWrapperError(): void
     {
+        $this->expectException(GitException::class);
         $badWrapper = './tests/dummy-wrapper-bad.sh';
         $this->gitWrapper->setPrivateKey('./tests/id_rsa', 22, $badWrapper);
     }
@@ -122,11 +119,9 @@ final class GitWrapperTest extends AbstractGitWrapperTestCase
         $this->assertGitVersion($version);
     }
 
-    /**
-     * @expectedException \GitWrapper\GitException
-     */
     public function testGitCommandError(): void
     {
+        $this->expectException(GitException::class);
         $this->runBadCommand();
     }
 
@@ -139,11 +134,9 @@ final class GitWrapperTest extends AbstractGitWrapperTestCase
         $this->assertGitVersion($version);
     }
 
-    /**
-     * @expectedException \GitWrapper\GitException
-     */
     public function testGitRunDirectoryError(): void
     {
+        $this->expectException(GitException::class);
         $command = new GitCommand();
         $command->setFlag('version');
         $command->setDirectory('/some/bad/directory');


### PR DESCRIPTION
I've refactored some tests, using:
- PHPUnit assertion method instead of PHP's;
- `assertSame` instead of `assertEquals`, to strict compare what we need;
- swipe some arguments, to match PHPUnit assertion method correct arguments order.

Thanks to [`Rector`](https://github.com/rectorphp/rector) find them.
