### PR TITLE
Use Symplify preset config file

### DIFF
--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -3,18 +3,9 @@ includes:
     - vendor/symplify/easy-coding-standard/config/php71.neon
     - vendor/symplify/easy-coding-standard/config/common.neon
     - vendor/symplify/easy-coding-standard/config/clean-code.neon
+    - vendor/symplify/easy-coding-standard/config/symplify.neon
 
 checkers:
-    - SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff
-
-    # Symplify set
-    - Symplify\CodingStandard\Fixer\Naming\PropertyNameMatchingTypeFixer
-    - Symplify\CodingStandard\Sniffs\Naming\AbstractClassNameSniff
-    - Symplify\CodingStandard\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer
-    - Symplify\CodingStandard\Fixer\Import\ImportNamespacedNameFixer
-    - Symplify\CodingStandard\Fixer\Naming\PropertyNameMatchingTypeFixer
-    - Symplify\CodingStandard\Fixer\Php\ClassStringToClassConstantFixer
-
     # Metrics
     PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff:
         absoluteLineLimit: 120
@@ -23,12 +14,11 @@ checkers:
     PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\NestingLevelSniff:
         absoluteNestingLevel: 4
 
-    # Class should be Final or Abstract
-    - SlamCsFixer\FinalInternalClassFixer
-
 parameters:
     exclude_checkers:
         - PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff
+        - Symplify\CodingStandard\Sniffs\Architecture\ExplicitExceptionSniff
+        - Symplify\CodingStandard\Sniffs\DependencyInjection\NoClassInstantiationSniff
 
     skip:
         SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff:

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -19,7 +19,6 @@ checkers:
 parameters:
     exclude_checkers:
         - PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff
-        - Symplify\CodingStandard\Sniffs\Architecture\ExplicitExceptionSniff
         - Symplify\CodingStandard\Sniffs\DependencyInjection\NoClassInstantiationSniff
 
     skip:

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -14,6 +14,8 @@ checkers:
     PHP_CodeSniffer\Standards\Generic\Sniffs\Metrics\NestingLevelSniff:
         absoluteNestingLevel: 4
 
+    # Class should be Final or Abstract
+    - SlamCsFixer\FinalInternalClassFixer
 parameters:
     exclude_checkers:
         - PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff

--- a/src/Event/GitLoggerListener.php
+++ b/src/Event/GitLoggerListener.php
@@ -2,7 +2,7 @@
 
 namespace GitWrapper\Event;
 
-use DomainException;
+use GitWrapper\GitException;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -57,7 +57,7 @@ final class GitLoggerListener implements EventSubscriberInterface, LoggerAwareIn
     public function getLogLevelMapping(string $eventName): string
     {
         if (! isset($this->logLevelMappings[$eventName])) {
-            throw new DomainException(sprintf('Unknown event "%s"', $eventName));
+            throw new GitException(sprintf('Unknown event "%s"', $eventName));
         }
 
         return $this->logLevelMappings[$eventName];

--- a/src/GitProcess.php
+++ b/src/GitProcess.php
@@ -4,6 +4,7 @@ namespace GitWrapper;
 
 use GitWrapper\Event\GitEvent;
 use GitWrapper\Event\GitEvents;
+use RuntimeException;
 use Symfony\Component\Process\Process;
 
 final class GitProcess extends Process

--- a/src/GitProcess.php
+++ b/src/GitProcess.php
@@ -4,7 +4,6 @@ namespace GitWrapper;
 
 use GitWrapper\Event\GitEvent;
 use GitWrapper\Event\GitEvents;
-use RuntimeException;
 use Symfony\Component\Process\Process;
 
 final class GitProcess extends Process
@@ -83,7 +82,7 @@ final class GitProcess extends Process
                         $output = $this->getOutput();
                     }
 
-                    throw new RuntimeException($output);
+                    throw new GitException($output);
                 }
             } else {
                 $dispatcher->dispatch(GitEvents::GIT_BYPASS, $event);

--- a/tests/Event/TestListener.php
+++ b/tests/Event/TestListener.php
@@ -22,7 +22,7 @@ final class TestListener
 
     public function methodCalled(string $method): bool
     {
-        return in_array($method, $this->methods);
+        return in_array($method, $this->methods, true);
     }
 
     public function getEvent(): GitEvent

--- a/tests/GitLoggerListenerTest.php
+++ b/tests/GitLoggerListenerTest.php
@@ -2,9 +2,9 @@
 
 namespace GitWrapper\Test;
 
-use DomainException;
 use GitWrapper\Event\GitLoggerListener;
 use GitWrapper\GitCommand;
+use GitWrapper\GitException;
 use Psr\Log\LogLevel;
 use Psr\Log\NullLogger;
 use Throwable;
@@ -36,7 +36,7 @@ final class GitLoggerListenerTest extends AbstractGitWrapperTestCase
 
     public function testGetInvalidLogLevelMapping(): void
     {
-        $this->expectException(DomainException::class);
+        $this->expectException(GitException::class);
         $listener = new GitLoggerListener(new NullLogger());
         $listener->getLogLevelMapping('bad.event');
     }

--- a/tests/GitWorkingCopyTest.php
+++ b/tests/GitWorkingCopyTest.php
@@ -2,7 +2,6 @@
 
 namespace GitWrapper\Test;
 
-use Exception;
 use GitWrapper\GitBranches;
 use GitWrapper\GitException;
 use GitWrapper\GitWorkingCopy;
@@ -707,7 +706,7 @@ PATCH;
             return;
         }
 
-        throw new Exception(sprintf('Tag "%s" should not exist', $tag));
+        throw new GitException(sprintf('Tag "%s" should not exist', $tag));
     }
 
     protected function assertRemoteMaster(GitWorkingCopy $gitWorkingCopy): void
@@ -724,7 +723,7 @@ PATCH;
             return;
         }
 
-        throw new Exception('Branch `master` should not exist');
+        throw new GitException('Branch `master` should not exist');
     }
 
     /**


### PR DESCRIPTION
I've clean up our `easy-coding-standard.neon` file:
- The excluded ones are already in `clean-code` preset;
- Use `symplify` preset, just excluding `ExplicitExceptionSniff` and `NoClassInstantiationSniff` as there are not in our Coding Standards :smile: 