### PR TITLE
Fix a bug on windows

### DIFF
--- a/src/GitCommand.php
+++ b/src/GitCommand.php
@@ -185,6 +185,6 @@ final class GitCommand
 
         $command = array_merge([$this->getCommand()], $this->buildOptions(), $this->args);
 
-        return $command;
+        return array_filter($command, 'strlen');
     }
 }

--- a/src/GitCommand.php
+++ b/src/GitCommand.php
@@ -185,6 +185,6 @@ final class GitCommand
 
         $command = array_merge([$this->getCommand()], $this->buildOptions(), $this->args);
 
-        return array_filter($command);
+        return $command;
     }
 }

--- a/src/GitProcess.php
+++ b/src/GitProcess.php
@@ -36,10 +36,7 @@ final class GitProcess extends Process
 
         // Resolve the working directory of the Git process. Use the directory
         // in the command object if it exists.
-        if ($cwd === null && ($directory = $gitCommand->getDirectory()) !== null &&
-            ! $cwd = realpath($directory)) {
-            throw new GitException('Path to working directory could not be resolved: ' . $directory);
-        }
+        $cwd = $this->resolveWorkingDirectory($cwd, $gitCommand);
 
         // Finalize the environment variables, an empty array is converted
         // to null which enherits the environment of the PHP process.
@@ -99,5 +96,18 @@ final class GitProcess extends Process
             $eventName,
             new GitEvent($this->gitWrapper, $this, $this->gitCommand)
         );
+    }
+
+    private function resolveWorkingDirectory(?string $cwd, GitCommand $gitCommand): ?string
+    {
+        if ($cwd === null) {
+            $directory = $gitCommand->getDirectory();
+            if ($directory !== null) {
+                if (! $cwd = realpath($directory)) {
+                    throw new GitException('Path to working directory could not be resolved: ' . $directory);
+                }
+            }
+        }
+        return $cwd;
     }
 }

--- a/src/GitProcess.php
+++ b/src/GitProcess.php
@@ -26,11 +26,13 @@ final class GitProcess extends Process
 
         // Build the command line options, flags, and arguments.
         $gitCommandLine = $gitCommand->getCommandLine();
-        $commandLine = array_merge([$gitWrapper->getGitBinary()], (array) $gitCommandLine);
-
-        // Support for executing an arbitrary git command.
+        $gitBinary = $gitWrapper->getGitBinary();
         if (is_string($gitCommandLine)) {
-            $commandLine = implode(' ', $commandLine);
+            // Support for executing an arbitrary git command.
+            $commandLine = '"' . $gitBinary . '" ' . $gitCommandLine;
+        } else {
+            $commandLine = $gitCommandLine;
+            array_unshift($commandLine, $gitBinary);
         }
 
         // Resolve the working directory of the Git process. Use the directory

--- a/src/GitProcess.php
+++ b/src/GitProcess.php
@@ -25,25 +25,20 @@ final class GitProcess extends Process
         $this->gitCommand = $gitCommand;
 
         // Build the command line options, flags, and arguments.
-        $gitCommandLine = $gitCommand->getCommandLine();
+        $commandLine = $gitCommand->getCommandLine();
         $gitBinary = $gitWrapper->getGitBinary();
-        if (is_string($gitCommandLine)) {
+        if (is_string($commandLine)) {
             // Support for executing an arbitrary git command.
-            $commandLine = '"' . $gitBinary . '" ' . $gitCommandLine;
+            $commandLine = '"' . $gitBinary . '" ' . $commandLine;
         } else {
-            $commandLine = $gitCommandLine;
             array_unshift($commandLine, $gitBinary);
         }
 
         // Resolve the working directory of the Git process. Use the directory
         // in the command object if it exists.
-        if ($cwd === null) {
-            $directory = $gitCommand->getDirectory();
-            if ($directory !== null) {
-                if (! $cwd = realpath($directory)) {
-                    throw new GitException('Path to working directory could not be resolved: ' . $directory);
-                }
-            }
+        if ($cwd === null && ($directory = $gitCommand->getDirectory()) !== null &&
+            ! $cwd = realpath($directory)) {
+            throw new GitException('Path to working directory could not be resolved: ' . $directory);
         }
 
         // Finalize the environment variables, an empty array is converted

--- a/src/GitProcess.php
+++ b/src/GitProcess.php
@@ -100,14 +100,19 @@ final class GitProcess extends Process
 
     private function resolveWorkingDirectory(?string $cwd, GitCommand $gitCommand): ?string
     {
-        if ($cwd === null) {
-            $directory = $gitCommand->getDirectory();
-            if ($directory !== null) {
-                if (! $cwd = realpath($directory)) {
-                    throw new GitException('Path to working directory could not be resolved: ' . $directory);
-                }
-            }
+        if ($cwd !== null) {
+            return $cwd;
         }
+
+        $directory = $gitCommand->getDirectory();
+        if ($directory === null) {
+            return $cwd;
+        }
+
+        if (! $cwd = realpath($directory)) {
+            throw new GitException('Path to working directory could not be resolved: ' . $directory);
+        }
+
         return $cwd;
     }
 }

--- a/src/GitWorkingCopy.php
+++ b/src/GitWorkingCopy.php
@@ -94,7 +94,7 @@ final class GitWorkingCopy
      */
     public function getStatus(): string
     {
-        return $this->gitWrapper->git('status -s', $this->directory);
+        return $this->run('status', ['-s']);
     }
 
     /**


### PR DESCRIPTION
On windows, git binary paths are usually at: "C:\Program Files\...".

When I use:
```php
GitWorkingCopy::getStatus();
```

It cause an error: 
![image](https://user-images.githubusercontent.com/25447002/42211194-8e36453e-7ee5-11e8-918f-0f850a647649.png)

I found `getStatus()` use `GitWrapper::git` to run a raw command, so I changed it to use `GitWorkingCopy::run` firstly, but `GitWrapper::git` is still not working if git binary path including spaces.

I reviewed the code of command line formating, found a bug of concat `gitBinary` and `gitCommandLine`, and it's now fixed.

My English is not professional, but I'm trying my best. Thanks.