### PR TITLE
Update head method to seperate args

### DIFF
--- a/src/GitBranches.php
+++ b/src/GitBranches.php
@@ -68,6 +68,6 @@ final class GitBranches implements IteratorAggregate
      */
     public function head(): string
     {
-        return trim($this->gitWorkingCopy->run('rev-parse', ['--abbrev-ref HEAD']));
+        return trim($this->gitWorkingCopy->run('rev-parse', ['--abbrev-ref', 'HEAD']));
     }
 }


### PR DESCRIPTION
Without separating calling the head method just results in a return of `--abbrev-ref HEAD`. Separating them results in the current branch being correctly returned