### PR TITLE
Crossplatform GitWorkingCopy::getRemotes()

### DIFF
--- a/src/GitWorkingCopy.php
+++ b/src/GitWorkingCopy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GitWrapper;
 
 use GitWrapper\Exception\GitException;
+use Nette\Utils\Strings;
 
 /**
  * Interacts with a working copy.
@@ -340,7 +341,7 @@ final class GitWorkingCopy
         }
 
         $remotes = [];
-        foreach (preg_split('/(\r\n|\r|\n)/', $result) as $remote) {
+        foreach (Strings::split($result, '#(\r\n|\r|\n)#') as $remote) {
             $remotes[$remote]['fetch'] = $this->getRemoteUrl($remote);
             $remotes[$remote]['push'] = $this->getRemoteUrl($remote, 'push');
         }

--- a/src/GitWorkingCopy.php
+++ b/src/GitWorkingCopy.php
@@ -340,7 +340,7 @@ final class GitWorkingCopy
         }
 
         $remotes = [];
-        foreach (explode(PHP_EOL, $result) as $remote) {
+        foreach (preg_split('/(\r\n|\r|\n)/', $result) as $remote) {
             $remotes[$remote]['fetch'] = $this->getRemoteUrl($remote);
             $remotes[$remote]['push'] = $this->getRemoteUrl($remote, 'push');
         }

--- a/src/GitWorkingCopy.php
+++ b/src/GitWorkingCopy.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GitWrapper;
 
 use GitWrapper\Exception\GitException;
-use RuntimeException;
+use Nette\Utils\Strings;
 
 /**
  * Interacts with a working copy.
@@ -676,12 +676,6 @@ final class GitWorkingCopy
 
     private function splitByNewline(string $string): array
     {
-        $result = preg_split('#(\r\n|\r|\n)#', $string);
-
-        if ($result === false) {
-            throw new RuntimeException(sprintf('Cannot split string "%s" by newline.', $string));
-        }
-
-        return $result;
+        return Strings::split($string, '#\R#');
     }
 }

--- a/src/GitWorkingCopy.php
+++ b/src/GitWorkingCopy.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace GitWrapper;
 
 use GitWrapper\Exception\GitException;
-use Nette\Utils\Strings;
+use RuntimeException;
 
 /**
  * Interacts with a working copy.
@@ -674,8 +674,14 @@ final class GitWorkingCopy
         }
     }
 
-    private function splitByNewline($string): array
+    private function splitByNewline(string $string): array
     {
-        return Strings::split($string, '#(\r\n|\r|\n)#');
+        $result = preg_split('#(\r\n|\r|\n)#', $string);
+
+        if ($result === false) {
+            throw new RuntimeException(sprintf('Cannot split string "%s" by newline.', $string));
+        }
+
+        return $result;
     }
 }

--- a/src/GitWorkingCopy.php
+++ b/src/GitWorkingCopy.php
@@ -341,7 +341,7 @@ final class GitWorkingCopy
         }
 
         $remotes = [];
-        foreach (Strings::split($result, '#(\r\n|\r|\n)#') as $remote) {
+        foreach ($this->splitByNewline($result) as $remote) {
             $remotes[$remote]['fetch'] = $this->getRemoteUrl($remote);
             $remotes[$remote]['push'] = $this->getRemoteUrl($remote, 'push');
         }
@@ -672,5 +672,10 @@ final class GitWorkingCopy
         if (empty($url)) {
             throw new GitException('Cannot add remote without a URL.');
         }
+    }
+
+    private function splitByNewline($string): array
+    {
+        return Strings::split($string, '#(\r\n|\r|\n)#');
     }
 }


### PR DESCRIPTION
In some configurations, there is no guarantee that the system uses `PHP_EOL` delimiter for console output. See issue https://github.com/yiisoft/yii-dev-tool/issues/42 for details.