### PR TITLE
Fixed dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
         "psr/log": "^1.1",
         "symplify/easy-coding-standard": "^7.0",
         "nette/utils": "^3.0",
-        "phpstan/phpstan": "^0.11.19",
+        "phpstan/phpstan": "^0.12.3",
+        "phpstan/phpstan-phpunit": "^0.12.3",
         "symplify/changelog-linker": "^7.0",
         "symplify/phpstan-extensions": "^7.0",
-        "rector/rector": "dev-master",
-        "tracy/tracy": "^2.7",
-        "phpstan/phpstan-phpunit": "^0.11.2"
+        "rector/rector": "^0.6.2",
+        "tracy/tracy": "^2.7"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ includes:
 parameters:
     level: max
     reportUnmatchedIgnoredErrors: false
+    checkMissingIterableValueType: false
 
     ignoreErrors:
         - '#Access to an undefined property object::\$data#'

--- a/src/GitBranches.php
+++ b/src/GitBranches.php
@@ -10,6 +10,8 @@ use Nette\Utils\Strings;
 
 /**
  * Class that parses and returnes an array of branches.
+ *
+ * @implements IteratorAggregate<int,string>
  */
 final class GitBranches implements IteratorAggregate
 {
@@ -43,6 +45,9 @@ final class GitBranches implements IteratorAggregate
         return ltrim($branch, ' *');
     }
 
+    /**
+     * @return ArrayIterator<int,string>
+     */
     public function getIterator(): ArrayIterator
     {
         $branches = $this->all();

--- a/src/GitCommand.php
+++ b/src/GitCommand.php
@@ -155,6 +155,10 @@ final class GitCommand
         $this->setOption($option, true);
     }
 
+    /**
+     * @param mixed $default
+     * @return mixed
+     */
     public function getOption(string $option, $default = null)
     {
         return $this->options[$option] ?? $default;

--- a/src/GitTags.php
+++ b/src/GitTags.php
@@ -10,6 +10,8 @@ use Nette\Utils\Strings;
 
 /**
  * Class that parses and returnes an array of Tags.
+ *
+ * @implements IteratorAggregate<int,string>
  */
 final class GitTags implements IteratorAggregate
 {
@@ -42,6 +44,9 @@ final class GitTags implements IteratorAggregate
         return ltrim($branch, ' *');
     }
 
+    /**
+     * @return ArrayIterator<int,string>
+     */
     public function getIterator(): ArrayIterator
     {
         $tags = $this->all();

--- a/src/GitWrapper.php
+++ b/src/GitWrapper.php
@@ -91,6 +91,9 @@ final class GitWrapper
         return $this->gitBinary;
     }
 
+    /**
+     * @param mixed $value
+     */
     public function setEnvVar(string $var, $value): void
     {
         $this->env[$var] = $value;
@@ -108,6 +111,7 @@ final class GitWrapper
      * @param string $var The name of the environment variable, e.g. "HOME", "GIT_SSH".
      * @param mixed $default The value returned if the environment variable is not set, defaults to
      *   null.
+     * @return mixed
      */
     public function getEnvVar(string $var, $default = null)
     {


### PR DESCRIPTION
The last run of travis showed the danger of using dev-master as a version, since dependency resolution is now totally broken. This PR should fix this.