### PR TITLE
getCommandLine should return string|string[]

### DIFF
--- a/src/GitCommand.php
+++ b/src/GitCommand.php
@@ -149,7 +149,7 @@ final class GitCommand
     /**
      * Renders the arguments and options for the Git command.
      *
-     * @return string|mixed[]
+     * @return string|string[]
      */
     public function getCommandLine()
     {
@@ -157,11 +157,16 @@ final class GitCommand
             return $this->command;
         }
 
-        $command = array_merge([$this->command], $this->buildOptions(), $this->args);
+        $command = [];
 
-        return array_filter($command, function ($value): bool {
-            return strlen($value) > 0;
-        });
+        foreach (array_merge([$this->command], $this->buildOptions(), $this->args) as $part) {
+            $value = (string) $part;
+            if (strlen($value) > 0) {
+                $command[] = $value;
+            }
+        }
+
+        return $command;
     }
 
     /**

--- a/src/GitCommand.php
+++ b/src/GitCommand.php
@@ -158,8 +158,9 @@ final class GitCommand
         }
 
         $command = [];
+        $parts = array_merge([$this->command], $this->buildOptions(), $this->args);
 
-        foreach (array_merge([$this->command], $this->buildOptions(), $this->args) as $part) {
+        foreach ($parts as $part) {
             $value = (string) $part;
             if (strlen($value) > 0) {
                 $command[] = $value;


### PR DESCRIPTION
The underlying symfony process class actually needs this to be string[], even though they only document the type as array in the Process constructor, but later they do an array_map to a function that is strongly typed as `string`...

---

Closes https://github.com/cpliakas/git-wrapper/issues/200.