### PR TITLE
Allow the Symfony 3.4 event dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.2",
         "symfony/process": "^4.4|^5.0",
-        "symfony/event-dispatcher": "^4.4|^5.0",
+        "symfony/event-dispatcher": "^3.4|^4.4|^5.0",
         "nette/utils": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
I would like to use this with Drupal 8 which still requires the Symfony 3.4 event dispatcher. There is hardly any difference between the 3.4 and 4.x versions of the event dispatcher, so there should be little harm in allowing this version.