### PR TITLE
SUPPORT for custom UserKnownHostsFile (cpliakas/git-wrapper#113)

### DIFF
--- a/bin/git-ssh-wrapper.sh
+++ b/bin/git-ssh-wrapper.sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-
-ssh -i $GIT_SSH_KEY -p $GIT_SSH_PORT -o StrictHostKeyChecking=no -o IdentitiesOnly=yes "$@"
+ssh -i $GIT_SSH_KEY -p $GIT_SSH_PORT $GIT_SSH_OPT_UserKnownHostsFile -o StrictHostKeyChecking=no -o IdentitiesOnly=yes "$@"

--- a/src/GitWrapper.php
+++ b/src/GitWrapper.php
@@ -141,6 +141,8 @@ final class GitWrapper
      *
      * @param string|null $wrapper Path the the GIT_SSH wrapper script, defaults to null which uses the
      *   script included with this library.
+     * @param string|null $UserKnownHostsFile PATH to the known_hosts file for ssh authentication, defaults
+     *   to null which doesn't inject the option in the SSH command
      */
     public function setPrivateKey(string $privateKey, int $port = 22, ?string $wrapper = null, ?string $UserKnownHostsFile = null): void
     {
@@ -156,10 +158,9 @@ final class GitWrapper
             throw new GitException('Path private key could not be resolved: ' . $privateKey);
         }
 
-        if ($UserKnownHostsFile === null ) {
+        if ($UserKnownHostsFile === null) {
             $optUserKnownHostsFile = '';
-        }
-        else {
+        } else {
             if (! $UserKnownHostsFilePath = realpath($UserKnownHostsFile)) {
                 throw new GitException('Path to UserKnownHostsFile  could not be resolved: ' . $UserKnownHostsFile);
             }
@@ -169,7 +170,7 @@ final class GitWrapper
         $this->setEnvVar('GIT_SSH', $wrapperPath);
         $this->setEnvVar('GIT_SSH_KEY', $privateKeyPath);
         $this->setEnvVar('GIT_SSH_PORT', $port);
-        $this->setEnvVar('GIT_SSH_OPT_UserKnownHostsFile',  $optUserKnownHostsFile);
+        $this->setEnvVar('GIT_SSH_OPT_UserKnownHostsFile', $optUserKnownHostsFile);
     }
 
     /**

--- a/src/GitWrapper.php
+++ b/src/GitWrapper.php
@@ -142,7 +142,7 @@ final class GitWrapper
      * @param string|null $wrapper Path the the GIT_SSH wrapper script, defaults to null which uses the
      *   script included with this library.
      */
-    public function setPrivateKey(string $privateKey, int $port = 22, ?string $wrapper = null): void
+    public function setPrivateKey(string $privateKey, int $port = 22, ?string $wrapper = null, ?string $UserKnownHostsFile = null): void
     {
         if ($wrapper === null) {
             $wrapper = __DIR__ . '/../bin/git-ssh-wrapper.sh';
@@ -156,9 +156,20 @@ final class GitWrapper
             throw new GitException('Path private key could not be resolved: ' . $privateKey);
         }
 
+        if ($UserKnownHostsFile === null ) {
+            $optUserKnownHostsFile = '';
+        }
+        else {
+            if (! $UserKnownHostsFilePath = realpath($UserKnownHostsFile)) {
+                throw new GitException('Path to UserKnownHostsFile  could not be resolved: ' . $UserKnownHostsFile);
+            }
+            $optUserKnownHostsFile = '-o UserKnownHostsFile=' . $UserKnownHostsFile;
+        }
+
         $this->setEnvVar('GIT_SSH', $wrapperPath);
         $this->setEnvVar('GIT_SSH_KEY', $privateKeyPath);
         $this->setEnvVar('GIT_SSH_PORT', $port);
+        $this->setEnvVar('GIT_SSH_OPT_UserKnownHostsFile',  $optUserKnownHostsFile);
     }
 
     /**
@@ -169,6 +180,7 @@ final class GitWrapper
         $this->unsetEnvVar('GIT_SSH');
         $this->unsetEnvVar('GIT_SSH_KEY');
         $this->unsetEnvVar('GIT_SSH_PORT');
+        $this->unsetEnvVar('GIT_SSH_OPT_UserKnownHostsFile');
     }
 
     public function addOutputEventSubscriber(AbstractOutputEventSubscriber $gitOutputEventSubscriber): void


### PR DESCRIPTION
As noted in the reported issue git-wrapper raise an error when performing remote connection.

Currently it is possible to solve the issue by creating a custom wrapper script and calling `setPrivateKey` with the script path.

```
public function setPrivateKey(string $privateKey, int $port = 22, ?string $wrapper = null): void
```

Basically to avoid the error you should set the UserKnownHostsFile to a custom `knownhosts` file (the one that usualy live in `$HOME\.ssh` directory) in a directory writable by `daemon`\`httpd` or set it to `/dev/null' in you script.

As alternative I suggest to include an additional setting in the `setPrivateKey` that allows to set the file (or `/dev/null/') directly in the configuration.

