### PR TITLE
Add exit code to GitException

### DIFF
--- a/src/Process/GitProcess.php
+++ b/src/Process/GitProcess.php
@@ -89,7 +89,7 @@ final class GitProcess extends Process
                     $output = $this->getOutput();
                 }
 
-                throw new GitException($output);
+                throw new GitException($output, $exitCode);
             }
         } catch (RuntimeException $runtimeException) {
             $gitErrorEvent = new GitErrorEvent($this->gitWrapper, $this, $this->gitCommand);


### PR DESCRIPTION
In case you want to know the exit code of the process for further error handling, it is now passed as error code